### PR TITLE
feat: header logo click goes back to Event Details tab

### DIFF
--- a/src/components/MainPage.jsx
+++ b/src/components/MainPage.jsx
@@ -6,7 +6,7 @@ import {
   EuiPageContentBody,
   EuiSpacer,
 } from "@elastic/eui";
-import { React, useState } from "react";
+import { React, useCallback, useState } from "react";
 import BottomBar from "./BottomBar";
 import EventDetails from "./panels/EventDetails";
 import SpeakersPanel from "./panels/SpeakersPanel";
@@ -65,11 +65,15 @@ function MainPage() {
     },
   ];
 
+  const onLogoClick = useCallback(() => {
+    onSelectedTabChanged("event");
+  }, []);
+
   return (
     <EuiPage paddingSize="none">
       <EuiFlexGroup className="eui-fullHeight">
         <EuiPageBody panelled>
-          <Navbar tabs={tabs} />
+          <Navbar tabs={tabs} onLogoClick={onLogoClick} />
           <EuiPageContent
             hasBorder={false}
             hasShadow={false}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,6 +10,9 @@ export default function Navbar(props) {
       <EuiPageHeader
         restrictWidth
         iconType={rainbowCluster}
+        iconProps={{
+          onClick: props.onLogoClick,
+        }}
         pageTitle={makeRainbowText()}
         rightSideItems={[
           addCalButtons(sessionTwo.dateAndTime, sessionTwo.calendarLink),


### PR DESCRIPTION
#### Describe your changes
Adding onClick event to header Logo icon to send the user back to Event Details tab.

#### Link to issue this resolves
#31 
#### Screenshot of changes(if relevant)
![logo-click-event](https://user-images.githubusercontent.com/53273645/192406951-22a38942-a980-48d1-bfc7-6e6a3ce34da0.gif)

<!--- Complete this checklist before opening this PR!  -->

- [x] The **title** should be something descriptive about what you're changes do. _(It will default to whatever you put as your commit message.)_
- [x] This **description** should include ...
  - [x] A short summary of your changes
  - [x] A link to the issue that relates to these changes
  - [x] A screenshot of the changes if possible!
- [x] Add `brittanyjoiner15` as a reviewer
- [x] Add yourself as assignee
